### PR TITLE
Log warnings to STDERR instead of STDOUT

### DIFF
--- a/converter/src/main/resources/logback.xml
+++ b/converter/src/main/resources/logback.xml
@@ -1,0 +1,13 @@
+<configuration>
+    <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
+        <target>System.err</target>
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{5} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="STDERR" />
+    </root>
+</configuration>
+


### PR DESCRIPTION
The warnings were getting captured in my output script which would fail to run when sent to H2.

This change ensures the warnings are noticed when the converter is run like:

```
java -jar converter/target/mysql2h2-converter-tool-0.1-SNAPSHOT.jar sample_mysql_dump.sql | gzip -c > output_h2_file.sql.gz
```
